### PR TITLE
Updates & PostCSS integration (up-to-date Autoprefixer)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@
  * gulp modules
  */
 var argv         = require('yargs').argv;
-var autoprefixer = require('gulp-autoprefixer');
+var autoprefixer = require('autoprefixer');
 var browsersync  = require('browser-sync').create();
 var cp           = require('child_process');
 var gulp         = require('gulp');
@@ -13,6 +13,7 @@ var named        = require('vinyl-named');
 var newer        = require('gulp-newer');
 var plumber      = require('gulp-plumber');
 var pngquant     = require('imagemin-pngquant');
+var postcss      = require('gulp-postcss');
 var sass         = require('gulp-sass');
 var uglify       = require('gulp-uglify');
 var watch        = require('gulp-watch');
@@ -100,9 +101,15 @@ gulp.task('server', ['jekyll-build'], function() {
 gulp.task('sass', function () {
   return gulp.src(paths.sass + '/**/*')
     .pipe(sass({outputStyle: config.sass.outputStyle}).on('error', sass.logError))
-    .pipe(autoprefixer({ browsers: config.autoprefixer.browsers }))
+    // .pipe(autoprefixer({ browsers: config.autoprefixer.browsers }))
+    .pipe(postcss([
+      autoprefixer({
+        browsers: config.autoprefixer.browsers
+      })
+    ]))
     .pipe(gulp.dest(paths.css));
 });
+
 
 /**
  * imagemin

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -101,7 +101,6 @@ gulp.task('server', ['jekyll-build'], function() {
 gulp.task('sass', function () {
   return gulp.src(paths.sass + '/**/*')
     .pipe(sass({outputStyle: config.sass.outputStyle}).on('error', sass.logError))
-    // .pipe(autoprefixer({ browsers: config.autoprefixer.browsers }))
     .pipe(postcss([
       autoprefixer({
         browsers: config.autoprefixer.browsers
@@ -109,7 +108,6 @@ gulp.task('sass', function () {
     ]))
     .pipe(gulp.dest(paths.css));
 });
-
 
 /**
  * imagemin

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frasco",
   "version": "0.5.3",
-  "description": "Jekyll starter project including full setup for gulp, Sass, Autoprefixer, Bourbon/Neat/Bitters, Browserify, imagemin, Browsersync, etc.",
+  "description": "Jekyll starter project including full setup for gulp, Sass, Autoprefixer, Bourbon/Neat/Bitters, Browserify, imagemin, Browsersync, PostCSS etc.",
   "main": "gulpfile.js",
   "scripts": {
     "start": "gulp",
@@ -26,6 +26,7 @@
     "imagemin",
     "Jekyll",
     "Neat",
+    "PostCSS",
     "Sass",
     "Webpack"
   ],
@@ -36,18 +37,19 @@
   },
   "homepage": "https://ixkaito.github.io/frasco",
   "devDependencies": {
+    "autoprefixer": "^6.5.1",
     "browser-sync": "^2.13.0",
     "gulp": "^3.9.1",
-    "gulp-autoprefixer": "^3.1.0",
     "gulp-imagemin": "^3.0.1",
     "gulp-newer": "^1.2.0",
     "gulp-plumber": "^1.1.0",
+    "gulp-postcss": "^6.2.0",
     "gulp-sass": "^2.3.2",
-    "gulp-uglify": "^1.5.4",
+    "gulp-uglify": "^2.0.0",
     "gulp-watch": "^4.3.8",
     "imagemin-pngquant": "^5.0.0",
     "vinyl-named": "^1.1.0",
     "webpack-stream": "^3.2.0",
-    "yargs": "^4.8.1"
+    "yargs": "^6.2.0"
   }
 }


### PR DESCRIPTION
Hey there,
I really like your this starter project and want to contribute, so here goes:
- Replacing gulp-autoprefixer (since it's deprecated) with autoprefixer (now part of the PostCSS ecosystem)
- This also allows for easy integration of other PostCSS plugins people might find useful -- see [http://postcss.parts/](http://postcss.parts/) (totally optional)
- Adding PostCSS as main feature of your starter project

Additionally JS linting might be nice to have, I prefer ESLint over JSHint, just let me know!
Good day to you, Sir

S1SYPHOS
