### PR TITLE
gulp-sass only copies the main scss file now.

### DIFF
--- a/gulp_tasks/sass.js
+++ b/gulp_tasks/sass.js
@@ -5,7 +5,7 @@ const postcss      = require('gulp-postcss');
 const sass         = require('gulp-sass');
 
 gulp.task('sass', function () {
-  return gulp.src(config.assets + '/' + config.sass.src + '/**/*')
+  return gulp.src(config.assets + '/' + config.sass.src + '/**/*.scss')
     .pipe(sass({outputStyle: config.sass.outputStyle}).on('error', sass.logError))
     .pipe(postcss([
       autoprefixer({


### PR DESCRIPTION
gulp-sass is copying over the folder structure of the source into the output destination, which results in empty folders inside of the destination. 
This resolves the issue by telling gulp-sass to watch only the `*.scss`