### PR TITLE
Fix gulp imagemin race conditions

### DIFF
--- a/gulp_tasks/build.js
+++ b/gulp_tasks/build.js
@@ -1,25 +1,17 @@
 const argv        = require('yargs').argv;
-const browsersync = require('browser-sync').create();
 const config      = require('../frasco.config.js');
 const cp          = require('child_process');
 const gulp        = require('gulp');
 
-let jekyll        = process.platform === 'win32' ? 'jekyll.bat' : 'jekyll';
-
-let build = [];
-Object.keys(config.tasks).forEach(function (key) {
-  if (config.tasks[key] && key != 'browsersync' && key != 'watch') {
-    build.push(key);
-  }
-});
-build.push('jekyll-build');
+const jekyll = process.platform === 'win32' ? 'jekyll.bat' : 'jekyll';
+const build = Object.keys(config.tasks).filter(key => ['browsersync', 'watch'].includes(key) === false);
 
 /**
  * Build the Jekyll Site
  */
-gulp.task('jekyll-build', function (done) {
+gulp.task('jekyll-build', build, function (done) {
   let jekyllConfig = config.jekyll.config.default;
-  if (argv.jekyllEnv == 'production') {
+  if (argv.jekyllEnv === 'production') {
     process.env.JEKYLL_ENV = 'production';
     jekyllConfig += config.jekyll.config.production ? ',' + config.jekyll.config.production : '';
   } else {
@@ -33,7 +25,7 @@ gulp.task('jekyll-build', function (done) {
  * Build task, this will minify the images, compile the sass,
  * bundle the js, but not launch BrowserSync and watch files.
  */
-gulp.task('build', build);
+gulp.task('build', ['jekyll-build']);
 
 /**
  * Test task, this use the build task.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,4 +18,4 @@ Object.keys(config.tasks).forEach(function (key) {
  * compile the sass, bundle the js, launch BrowserSync, and
  * watch files.
  */
-gulp.task('default', tasks);
+gulp.task('default', ['browsersync']);


### PR DESCRIPTION
Without this you will run into a race condition where jekyll-build runs without images in the assets directory